### PR TITLE
sql script to seed any region market, with market saturation and item category option

### DIFF
--- a/sql/seed_market.sql
+++ b/sql/seed_market.sql
@@ -1,7 +1,7 @@
 -- seeds specified rgion with skills and ships
 
 set @regionid=10000002; -- regionID, this is The Forge
-set @saturation=0.2; -- 20% of stations are filled with orders
+set @saturation=0.6; -- 60% of stations are filled with orders
 -- change "categoryID in (16,6)" to categories you want to be seeded
 
 use evemu;


### PR DESCRIPTION
The default version seeds The Forge region (the one with Jita) with ships and skills, but it can be easily configured.
To configure, change the following things:
@regionid = region id,
@saturation = percentage of stations to be seeded. (0.2 means 20% of stations will recieve orders)
"categoryID in (16, 6)" changes categories to seed. 6 and 16 are skills and ships

This script basically mimcs the behavior of "Market seed" feature in EVEmu Control Panel.
It sets reasonable prices, not that huge billion ones.
