### PR TITLE
Fix for Bug #75.  Server Crash on loading systems with Characters who ha...

### DIFF
--- a/src/eve-server/Client.cpp
+++ b/src/eve-server/Client.cpp
@@ -84,6 +84,7 @@ Client::~Client() {
         GetShip()->SaveShip();                              // Save Ship's and Modules' attributes and info to DB
         GetChar()->SaveCharacter();                         // Save Character info to DB
         GetChar()->SaveSkillQueue();                        // Save Skill Queue to DB
+        GetChar()->UpdateSkillQueueEndTime();               // Save Queue End Time to DB
 
         // remove ourselves from system
         if(m_system != NULL)

--- a/src/eve-server/character/Character.cpp
+++ b/src/eve-server/character/Character.cpp
@@ -902,8 +902,6 @@ void Character::UpdateSkillQueue()
     SaveCharacter();
     SaveSkillQueue();
 
-    // update queue end time:
-    UpdateSkillQueueEndTime(m_skillQueue);
 }
 
 //  this still needs work...have to check for multiple levels of same skill.
@@ -929,6 +927,11 @@ void Character::UpdateSkillQueueEndTime(const SkillQueue &queue)
         return;
     }
     return;
+}
+
+void Character::UpdateSkillQueueEndTime()
+{
+    UpdateSkillQueueEndTime(m_skillQueue);
 }
 
 PyDict *Character::CharGetInfo() {

--- a/src/eve-server/character/Character.h
+++ b/src/eve-server/character/Character.h
@@ -438,6 +438,7 @@ public:
      * Update skill training end time on char select screen.
      * @author allan
      */
+    void UpdateSkillQueueEndTime();
     void UpdateSkillQueueEndTime( const SkillQueue &queue);
 
     /* GrantCertificate( uint32 certificateID )


### PR DESCRIPTION
...ve finished skills still in queue.

This moves the UpdateSkillQueueEndTime() function call from UpdateSkillQueue() to
the Client::~Client() destructor.  This also saves on DB calls as it is only called when
the client exits the server, instead of making another DB call at every UpdateSkillQueue().
