### PR TITLE
Added quantity to the list of attributes to not warn about.

### DIFF
--- a/src/eve-server/inventory/EVEAttributeMgr.cpp
+++ b/src/eve-server/inventory/EVEAttributeMgr.cpp
@@ -404,6 +404,7 @@ EvilNumber AttributeMap::GetAttribute( const uint32 attributeId ) const
         // ONLY output ERROR message for a "missing" attributeID if it is not in the list of commonly "not found" attributes:
         switch( attributeId )
         {
+			case AttrQuantity:
             case AttrRequiredSkill2:
             case AttrRequiredSkill3:
             case AttrRequiredSkill4:


### PR DESCRIPTION
Most items don't have a quantity attribute. Stops spam that could look like an issue to newcomers.
