### PR TITLE
Fixed ship name on creation

### DIFF
--- a/src/eve-server/ship/ShipService.cpp
+++ b/src/eve-server/ship/ShipService.cpp
@@ -419,12 +419,10 @@ PyResult ShipBound::Handle_AssembleShip(PyCallArgs &call) {
         }
     }
 
-    // Not a c++ guy, probably a way more efficient way to do this.
-    // Also probably goes out of bounds at some point. Someone needs to look at this
-    // and check if it is 'safe' for long char names.
-    std::string name = call.client->GetChar()->itemName().substr(1); // substr because it returned a space before the item name...
-    name.append("'s ");
-    name.append(ship->itemName());
+    // Checked on live, this cannot be larger than 20
+    std::string name = call.client->GetCharacterName().append("'s").append(ship->itemName());
+    if(name.length() > 20)
+        name.resize(20);
     ship->Rename(name.c_str());
 
     return NULL;


### PR DESCRIPTION
Set ship names properly as on live, max size is 20, if char name + ship name exceeds 20 chars, resize.
Removed the `.substr(1)` as it was due to error in my database.