### PR TITLE
Compile time cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ CMAKE_MINIMUM_REQUIRED( VERSION 2.8.8 FATAL_ERROR )
 PROJECT( "evemu" )
 SET( PROJECT_DESCRIPTION_SUMMARY "A server emulator for EVE Online" )
 SET( PROJECT_VENDOR              "The EVEmu development team" )
-SET( PROJECT_VERSION             "this is not used anymore, CMake pulls version from Git Tree Info (cmake/GitTreeInfo.cmake)" )
+SET( PROJECT_VERSION             "0" )
 SET( PROJECT_REPOSITORY          "https://github.com/evemuproject/evemu_server" )
 
 # Append our module path

--- a/cmake/GitTreeInfo.cmake
+++ b/cmake/GitTreeInfo.cmake
@@ -54,21 +54,21 @@ MACRO( GIT_TREE_INFO PATH PREFIX )
                    ERROR_QUIET )
 
   # Build a nice version string
-  IF( "${PREFIX}_TAG_EXACT" )
+  IF( ${PREFIX}_TAG_EXACT )
     # We have an exact tag, use that and nothing else
     SET( "${PREFIX}_VERSION" "${${PREFIX}_TAG_EXACT}" )
-  ELSE( "${PREFIX}_TAG_EXACT" )
+  ELSE( ${PREFIX}_TAG_EXACT )
     # Set version to hash (hash is always available)
     SET( "${PREFIX}_VERSION" "${${PREFIX}_HASH}" )
 
     # If we have branch name, prepend it
-    IF( "${PREFIX}_BRANCH" )
+    IF( ${PREFIX}_BRANCH )
       SET( "${PREFIX}_VERSION" "${${PREFIX}_BRANCH}-${${PREFIX}_VERSION}" )
-    ENDIF( "${PREFIX}_BRANCH" )
+    ENDIF( ${PREFIX}_BRANCH )
 
     # If we have last tag, prepend it
-    IF( "${PREFIX}_TAG_LAST" )
+    IF( ${PREFIX}_TAG_LAST )
       SET( "${PREFIX}_VERSION" "${${PREFIX}_TAG_LAST}-${${PREFIX}_VERSION}" )
-    ENDIF( "${PREFIX}_TAG_LAST" )
-  ENDIF( "${PREFIX}_TAG_EXACT" )
+    ENDIF( ${PREFIX}_TAG_LAST )
+  ENDIF( ${PREFIX}_TAG_EXACT )
 ENDMACRO( GIT_TREE_INFO )

--- a/src/eve-server/Client.cpp
+++ b/src/eve-server/Client.cpp
@@ -1788,7 +1788,7 @@ bool Client::Handle_CallReq( PyPacket* packet, PyCallStream& req )
             sLog.Error("Client","Unable to find service to handle call to: %s", packet->dest.service.c_str());
             packet->dest.Dump(CLIENT__ERROR, "    ");
 
-#pragma message( "TODO: throw proper exception to client (exceptions.ServiceNotFound)." )
+            //TODO: throw proper exception to client (exceptions.ServiceNotFound).
             throw PyException( new PyNone );
         }
     }

--- a/src/eve-server/admin/GMCommands.cpp
+++ b/src/eve-server/admin/GMCommands.cpp
@@ -1504,7 +1504,7 @@ PyResult Command_kill( Client* who, CommandDB* db, PyServiceMgr* services, const
         uint32 entity = atoi( args.arg( 1 ).c_str() );
 
         InventoryItemRef itemRef = services->item_factory.GetShip(entity);
-        if( itemRef == NULL )
+        if( itemRef.get() == NULL )
             throw PyException( MakeCustomError("/kill NOT supported on non-ship types at this time") );
 
         // WARNING: This cast of SystemEntity * to DynamicSystemEntity * will CRASH if the get() does not return

--- a/src/eve-server/character/Character.cpp
+++ b/src/eve-server/character/Character.cpp
@@ -1171,7 +1171,7 @@ void Character::SaveFullCharacter()
         //cur->get()->SaveAttributes();
 */
 	SkillRef currentTraining = GetSkillInTraining();
-	if( currentTraining != NULL )
+	if( currentTraining.get() != NULL )
 		currentTraining->SaveItem();
 
     // Loop through all items owned by this Character and save each one:

--- a/src/eve-server/character/CharacterDB.cpp
+++ b/src/eve-server/character/CharacterDB.cpp
@@ -676,7 +676,7 @@ void CharacterDB::SetAvatarModifiers(uint32 charID, PyRep* modifierLocationID,  
 		charID,
 		modifierLocationID->AsInt()->value(),
 		paperdollResourceID->AsInt()->value(),
-		paperdollResourceVariation->IsInt() ? paperdollResourceVariation->AsInt()->value() : NULL ))
+		paperdollResourceVariation->IsInt() ? paperdollResourceVariation->AsInt()->value() : 0 ))
 	{
 		codelog(SERVICE__ERROR, "Error in query: %s", err.c_str());
 	}
@@ -691,9 +691,9 @@ void CharacterDB::SetAvatarSculpts(uint32 charID, PyRep* sculptLocationID, PyRep
 		"VALUES (%u, %u, %f, %f, %f)",
 		charID,
 		sculptLocationID->AsInt()->value(),
-		weightUpDown->IsFloat() ? weightUpDown->AsFloat()->value() : NULL,
-		weightLeftRight->IsFloat() ? weightLeftRight->AsFloat()->value() : NULL,
-		weightForwardBack->IsFloat() ? weightForwardBack->AsFloat()->value() : NULL))
+		weightUpDown->IsFloat() ? weightUpDown->AsFloat()->value() : 0.0f,
+		weightLeftRight->IsFloat() ? weightLeftRight->AsFloat()->value() : 0.0f,
+		weightForwardBack->IsFloat() ? weightForwardBack->AsFloat()->value() : 0.0f))
 	{
 		codelog(SERVICE__ERROR, "Error in query: %s", err.c_str());
 	}

--- a/src/eve-server/character/SkillMgrService.cpp
+++ b/src/eve-server/character/SkillMgrService.cpp
@@ -245,7 +245,7 @@ PyResult SkillMgrBound::Handle_RespecCharacter(PyCallArgs &call)
     }
 	
 	CharacterRef cref = call.client->GetChar();
-	if(cref->GetSkillInTraining() != NULL) 
+	if( cref->GetSkillInTraining() )
 		throw(PyException(MakeUserError("RespecSkillInTraining")));
 
     // return early if this is an illegal call

--- a/src/eve-server/config/ConfigDB.cpp
+++ b/src/eve-server/config/ConfigDB.cpp
@@ -28,7 +28,7 @@
 #include "config/ConfigDB.h"
 
 PyRep *ConfigDB::GetMultiOwnersEx(const std::vector<int32> &entityIDs) {
-#   pragma message( "we need to deal with corporations!" )
+    //TODO: we need to deal with corporations!
 
     //im not sure how this query is supposed to work, as far as what table
     //we use to get the fields from.
@@ -259,7 +259,7 @@ PyObjectEx *ConfigDB::GetMapObjects(uint32 entityID, bool wantRegions,
 
     DBQueryResult res;
 
-#   pragma message( "hacked 'connector' field in GetMapObjects" )
+    //TODO: hacked 'connector' field in GetMapObjects
 
     if(!sDatabase.RunQuery(res,
         "SELECT "
@@ -282,7 +282,7 @@ PyObjectEx *ConfigDB::GetMapObjects(uint32 entityID, bool wantRegions,
 PyObject *ConfigDB::GetMap(uint32 solarSystemID) {
     DBQueryResult res;
 
-#   pragma message( "a lot of missing data in GetMap" )
+    //TODO: a lot of missing data in GetMap
 
     //how in the world do they get a list in the freakin rowset for destinations???
     if(!sDatabase.RunQuery(res,

--- a/src/eve-server/dogmaim/DogmaIMService.cpp
+++ b/src/eve-server/dogmaim/DogmaIMService.cpp
@@ -265,7 +265,7 @@ PyResult DogmaIMBound::Handle_LoadAmmoToBank( PyCallArgs& call ) {
 	// Get Reference to Ship, Module, and Charge
 	ShipRef shipRef = call.client->GetShip();
 	InventoryItemRef moduleRef = shipRef->GetModule(args.moduleItemID);
-	if( moduleRef == NULL )
+	if( moduleRef.get() == NULL )
 	{
 		sLog.Error("DogmaIMBound::Handle_LoadAmmoToBank()", "ERROR: cannot find module into which charge should be loaded!  How did we get here!?!?!" );
 		return NULL;
@@ -555,7 +555,7 @@ PyResult DogmaIMBound::Handle_GetAllInfo( PyCallArgs& call )
 
     //Contains a dict of the ship and its modules
 
-    if(call.client->GetShip() == NULL) {
+    if( call.client->GetShip().get() == NULL ) {
         codelog(SERVICE__ERROR, "Unable to build ship status for ship %u", call.client->GetShipID());
         return NULL;
     }

--- a/src/eve-server/mail/MailDB.cpp
+++ b/src/eve-server/mail/MailDB.cpp
@@ -190,5 +190,5 @@ int MailDB::BitFromLabelID(int id)
 
     // This just gets rid of a warning, code execution should never reach here.
     sLog.Error("MailDB::BitFromLabelID", "ERROR: Could not get bit.");
-    return NULL;
+    return 0;
 }

--- a/src/eve-server/market/MarketProxyService.cpp
+++ b/src/eve-server/market/MarketProxyService.cpp
@@ -185,9 +185,9 @@ PyResult MarketProxyService::Handle_GetOrders(PyCallArgs &call) {
     method_name += itoa(args.arg);
     ObjectCachedMethodID method_id(GetName(), method_name.c_str());
 
-#   pragma message( "TODO: temporary solution, make cache objects with arguments" )
+    //TODO: temporary solution, make cache objects with arguments
 
-#    pragma message("TODO: need to check if cache is refreshed when marker orders change.")
+    //TODO: need to check if cache is refreshed when marker orders change.
 //    m_manager->cache_service->InvalidateCache(method_id);
 
     //check to see if this method is in the cache already.

--- a/src/eve-server/ship/ModuleManager.cpp
+++ b/src/eve-server/ship/ModuleManager.cpp
@@ -810,7 +810,7 @@ ModuleManager::ModuleManager(Ship *const ship)
 					moduleRef = (*cur);
 				cur++;
 			}
-			if( !(moduleRef == NULL) )
+			if( moduleRef )
 			{
 				if( _fitModule( moduleRef, (EVEItemFlags)flagIndex ) )
 				{
@@ -819,7 +819,7 @@ ModuleManager::ModuleManager(Ship *const ship)
 						Online(moduleRef->itemID());
 					else
 						Offline(moduleRef->itemID());
-					if( chargeRef != NULL )
+					if( chargeRef )
 						((ActiveModule *)GetModule((EVEItemFlags)flagIndex))->Load(chargeRef);
 				}
 				else
@@ -849,7 +849,7 @@ ModuleManager::ModuleManager(Ship *const ship)
 					moduleRef = (*cur);
 				cur++;
 			}
-			if( !(moduleRef == NULL) )
+			if( moduleRef )
 			{
 				if( _fitModule( moduleRef, (EVEItemFlags)flagIndex ) )
 				{
@@ -858,7 +858,7 @@ ModuleManager::ModuleManager(Ship *const ship)
 						Online(moduleRef->itemID());
 					else
 						Offline(moduleRef->itemID());
-					if( chargeRef != NULL )
+					if( chargeRef )
 						((ActiveModule *)GetModule((EVEItemFlags)flagIndex))->Load(chargeRef);
 				}
 				else
@@ -888,7 +888,7 @@ ModuleManager::ModuleManager(Ship *const ship)
 					moduleRef = (*cur);
 				cur++;
 			}
-			if( !(moduleRef == NULL) )
+			if( moduleRef )
 			{
 				if( _fitModule( moduleRef, (EVEItemFlags)flagIndex ) )
 				{
@@ -896,7 +896,7 @@ ModuleManager::ModuleManager(Ship *const ship)
 						Online(moduleRef->itemID());
 					else
 						Offline(moduleRef->itemID());
-					if( chargeRef != NULL )
+					if( chargeRef )
 						((ActiveModule *)GetModule((EVEItemFlags)flagIndex))->Load(chargeRef);
 				}
 				else
@@ -923,7 +923,7 @@ ModuleManager::ModuleManager(Ship *const ship)
 			}
 			if( cur->get()->categoryID() == EVEDB::invCategories::Module )
 				itemRef = (*cur);
-			if( !(itemRef == NULL) )
+			if( itemRef )
 			{
 				_fitModule( itemRef, (EVEItemFlags)flagIndex );
 				// We don't think Rigs need the Online attribute set, but keep this code here in case we do:
@@ -950,7 +950,7 @@ ModuleManager::ModuleManager(Ship *const ship)
 			}
 			if( cur->get()->categoryID() == EVEDB::invCategories::Module )
 				itemRef = (*cur);
-			if( !(itemRef == NULL) )
+			if( itemRef )
 			{
 				_fitModule( itemRef, (EVEItemFlags)flagIndex );
 				// We don't think Subsystems need the Online attribute set, but keep this code here in case we do:

--- a/src/eve-server/ship/Ship.cpp
+++ b/src/eve-server/ship/Ship.cpp
@@ -884,7 +884,7 @@ uint32 Ship::AddItem(EVEItemFlags flag, InventoryItemRef item)
 			{
 				m_ModuleManager->LoadCharge(item, flag);
 				InventoryItemRef loadedChargeOnModule = m_ModuleManager->GetLoadedChargeOnModule(flag);
-				if( loadedChargeOnModule != NULL )
+				if( loadedChargeOnModule )
 				{
 					return loadedChargeOnModule->itemID();
 				}

--- a/src/eve-server/ship/ShipOperatorInterface.cpp
+++ b/src/eve-server/ship/ShipOperatorInterface.cpp
@@ -171,7 +171,7 @@ uint32 ShipOperatorInterface::GetLocationID() const
     assert(false);
 
     // Hack to get rid of warning, code execution should never reach this point
-    return NULL;
+    return 0;
 }
 
 void ShipOperatorInterface::MoveItem(uint32 itemID, uint32 location, EVEItemFlags flag)

--- a/src/eve-server/ship/TargetManager.cpp
+++ b/src/eve-server/ship/TargetManager.cpp
@@ -465,7 +465,7 @@ uint32 TargetManager::TimeToLock(ShipRef ship, SystemEntity *target) const {
     EvilNumber scanRes = ship->GetAttribute(AttrScanResolution);
     EvilNumber sigRad(500);
 
-	if( target->Item() != NULL )
+	if( target->Item().get() != NULL )
 		if( target->Item()->HasAttribute(AttrSignatureRadius) )
 			sigRad = target->Item()->GetAttribute(AttrSignatureRadius);
 

--- a/src/eve-server/ship/modules/mining_modules/MiningLaser.cpp
+++ b/src/eve-server/ship/modules/mining_modules/MiningLaser.cpp
@@ -106,7 +106,7 @@ void MiningLaser::Activate(SystemEntity * targetEntity)
 			// Charged mining laser:
 			// + Modulated Strip Miner II
 			// + Modulated Deep Core Strip Miner II
-			if( m_chargeRef != NULL )
+			if( m_chargeRef )
 			{
 				m_targetEntity = targetEntity;
 				m_targetID = targetEntity->Item()->itemID();
@@ -248,7 +248,7 @@ void MiningLaser::_ProcessCycle()
 	// Calculate how many units of ore to pull from the asteroid on this cycle:
 	//oreUnitsToPull = asteroidRef->GetAttribute(AttrMiningAmount).get_float() / oreUnitVolume;
 	oreUnitsToPull = moduleRef->GetAttribute(AttrMiningAmount).get_float() / oreUnitVolume;
-	if( m_chargeRef != NULL )
+	if( m_chargeRef )
 	{
 		// Use mining crystal charge to multiply ore amount taken:
 		if( moduleRef->HasAttribute(AttrSpecialisationAsteroidYieldMultiplier) )

--- a/src/eve-server/ship/modules/weapon_modules/EnergyTurret.cpp
+++ b/src/eve-server/ship/modules/weapon_modules/EnergyTurret.cpp
@@ -84,7 +84,7 @@ void EnergyTurret::DestroyRig()
 
 void EnergyTurret::Activate(SystemEntity * targetEntity)
 {
-	if( this->m_chargeRef != NULL )
+	if( this->m_chargeRef )
 	{
 		m_targetEntity = targetEntity;
 		m_targetID = targetEntity->Item()->itemID();

--- a/src/eve-server/ship/modules/weapon_modules/HybridTurret.cpp
+++ b/src/eve-server/ship/modules/weapon_modules/HybridTurret.cpp
@@ -89,7 +89,7 @@ void HybridTurret::DestroyRig()
 
 void HybridTurret::Activate(SystemEntity * targetEntity)
 {
-	if( this->m_chargeRef != NULL )
+	if( this->m_chargeRef )
 	{
 		m_targetEntity = targetEntity;
 		m_targetID = targetEntity->Item()->itemID();

--- a/src/eve-server/ship/modules/weapon_modules/MissileLauncher.cpp
+++ b/src/eve-server/ship/modules/weapon_modules/MissileLauncher.cpp
@@ -84,7 +84,7 @@ void MissileLauncher::DestroyRig()
 
 void MissileLauncher::Activate(SystemEntity * targetEntity)
 {
-	if( this->m_chargeRef != NULL )
+	if( this->m_chargeRef )
 	{
 		m_targetEntity = targetEntity;
 		m_targetID = targetEntity->Item()->itemID();

--- a/src/eve-server/ship/modules/weapon_modules/ProjectileTurret.cpp
+++ b/src/eve-server/ship/modules/weapon_modules/ProjectileTurret.cpp
@@ -89,7 +89,7 @@ void ProjectileTurret::DestroyRig()
 
 void ProjectileTurret::Activate(SystemEntity * targetEntity)
 {
-	if( this->m_chargeRef != NULL )
+	if( this->m_chargeRef )
 	{
 		m_targetEntity = targetEntity;
 		m_targetID = targetEntity->Item()->itemID();

--- a/src/eve-server/standing/StandingDB.cpp
+++ b/src/eve-server/standing/StandingDB.cpp
@@ -83,7 +83,7 @@ PyObjectEx *StandingDB::GetCorpStandings(uint32 corporationID) {
 PyObject *StandingDB::GetCharPrimeStandings(uint32 characterID) {
     DBQueryResult res;
 
-#   pragma message( "hacking GetCharPrimeStandings until we know what it does" )
+    //TODO: hacking GetCharPrimeStandings until we know what it does
 
     if(!sDatabase.RunQuery(res,
         "SELECT "


### PR DESCRIPTION
Removed all unnecessary warnings and notifications from compile time.

RefPtr usage errors have been fixed
NULL checking has been fixed.
#pragma message notices have been removed in favour of //TODO as most IDE's support finding them easier.
CMake policy (CMP0054) warnings have been fixed.
