### PR TITLE
Fix missing config.h error for pre-compiled headers

### DIFF
--- a/cmake/TargetBuildPCH.cmake
+++ b/cmake/TargetBuildPCH.cmake
@@ -25,6 +25,7 @@ FUNCTION( TARGET_BUILD_PCH TARGET HEADER SOURCE )
                             COMMAND "${CMAKE_CXX_COMPILER}"
                                     ARGS "$(CXX_DEFINES)"
                                          "$(CXX_FLAGS)"
+                                         "$(CXX_INCLUDES)"
                                          -o "${HEADER_GCH}"
                                          -c "${HEADER}"
                             DEPENDS "${CMAKE_CURRENT_OUTPUT_DIR}/flags.make"


### PR DESCRIPTION
For whatever reason some build environments have issues compiling pre-compiled headers without being given CXX_INCLUDES

This should fix the long standing issue with people being unable to compile the server