### PR TITLE
Update MySQL mirror to use oracle's repackaged archives 

### DIFF
--- a/cmake/BuildMySQL.cmake
+++ b/cmake/BuildMySQL.cmake
@@ -78,9 +78,8 @@ SET( MYSQL_URL
 #  "http://downloads.mysql.com/archives/mysql-5.1/${PKG_ARCHIVE}"
 #  "http://downloads.mysql.com/archives/mysql-5.5/${PKG_ARCHIVE}"
 #  "https://downloads.skysql.com/archives/mysql-5.5/${PKG_ARCHIVE}"
- # "ftp://ftp.fu-berlin.de/unix/databases/mysql/Downloads/MySQL-5.5/${PKG_ARCHIVE}"
+# "ftp://ftp.fu-berlin.de/unix/databases/mysql/Downloads/MySQL-5.5/${PKG_ARCHIVE}"
  "https://downloads.mysql.com/archives/get/file/${PKG_ARCHIVE}"
- 
   CACHE STRING "URL of the MySQL source archive" )
 MARK_AS_ADVANCED( MYSQL_URL )
 

--- a/cmake/BuildMySQL.cmake
+++ b/cmake/BuildMySQL.cmake
@@ -16,14 +16,14 @@ IF( WIN32 )
   IF( CMAKE_SIZEOF_VOID_P EQUAL 8 )
     # Windows 64-bit
     SET( PKG_NAME "mysql-5.5.25a-winx64" )
-    SET( PKG_MD5 "80ad4487e09b9b6967c48188aafa888e" )
+    SET( PKG_MD5 "8157cafab6f57418b441c228f6db3992" )
 #    # Windows 64-bit
 #    SET( PKG_NAME "mysql-noinstall-5.1.63-winx64" )
 #    SET( PKG_MD5 "ae0289b7788666b1254d14b001ff6ba9" )
   ELSE()
     # Windows 32-bit
     SET( PKG_NAME "mysql-5.5.25a-win32" )
-    SET( PKG_MD5 "d41d8cd98f00b204e9800998ecf8427e" )
+    SET( PKG_MD5 "df745c7bb9d34cac29503a4e36e3e8c8" )
     #SET( PKG_MD5 "859a538879d9f8ed06dcdcec9475aa78" )
 #    # Windows 32-bit
 #    SET( PKG_NAME "mysql-5.1.63" )
@@ -39,11 +39,11 @@ ELSEIF( ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" )
   IF( CMAKE_SIZEOF_VOID_P EQUAL 8 )
 	# MAC OS-X 64-bit
   	SET( PKG_NAME "mysql-5.5.25a-osx10.6-x86_64" )
-	SET( PKG_MD5 "6e3c37db5f0b0f7b239790d854c75b70")
+	SET( PKG_MD5 "261aa316160c65435a7359cc57561014")
   ELSE()
 	# MAC OS-X 32-bit
 	SET( PKG_NAME "mysql-5.5.25a-osx10.6-x86" )
-	SET( PKG_MD5 "e382787cd7307ff68d7cc9a56c60f9d9")
+	SET( PKG_MD5 "56f19c779a567ef27b82a2df8252facc")
   ENDIF()
   # MAC OS-X
   SET( PKG-ARCHIVE "${PKG_NAME}.tar.gz" )
@@ -54,14 +54,14 @@ ELSE ( WIN32 )
   IF( CMAKE_SIZEOF_VOID_P EQUAL 8 )
     # Linux 64-bit
     SET( PKG_NAME "mysql-5.5.25a-linux2.6-x86_64" )
-    SET( PKG_MD5 "15f29a6eb9bbd3f03a74aa524e7f1531" )
+    SET( PKG_MD5 "217f97e79d68d931a4790790ea8a8894" )
 #    # Linux 64-bit
 #    SET( PKG_NAME "mysql-5.1.63-linux-x86_64-glibc23" )
 #    SET( PKG_MD5 "594ea37fcd9f29a9e3eddf38e7288e3f" )
   ELSE()
     # Linux 32-bit
     SET( PKG_NAME "mysql-5.5.25a-linux2.6-i686" )
-    SET( PKG_MD5 "1f054641e48414a28a9adb1c6446e475" )
+    SET( PKG_MD5 "ff5d742bfff4a0b8ef48da336f13e6a6" )
 #    # Linux 32-bit
 #    SET( PKG_NAME "mysql-5.1.63-linux-i686-glibc23" )
 #    SET( PKG_MD5 "c3a8581320fdd7d11946456d6b3e9d7b" )
@@ -78,7 +78,9 @@ SET( MYSQL_URL
 #  "http://downloads.mysql.com/archives/mysql-5.1/${PKG_ARCHIVE}"
 #  "http://downloads.mysql.com/archives/mysql-5.5/${PKG_ARCHIVE}"
 #  "https://downloads.skysql.com/archives/mysql-5.5/${PKG_ARCHIVE}"
-  "ftp://ftp.fu-berlin.de/unix/databases/mysql/Downloads/MySQL-5.5/${PKG_ARCHIVE}"
+ # "ftp://ftp.fu-berlin.de/unix/databases/mysql/Downloads/MySQL-5.5/${PKG_ARCHIVE}"
+ "https://downloads.mysql.com/archives/get/file/${PKG_ARCHIVE}"
+ 
   CACHE STRING "URL of the MySQL source archive" )
 MARK_AS_ADVANCED( MYSQL_URL )
 


### PR DESCRIPTION
The old mirror died so I decided to change it to use Oracle's archive mirrors.  The hashes changed on all of the files so I updated all of those as well.