### PR TITLE
Compose update to support multistage builds.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,8 @@
-**/.git
+*
+!src
+!utils
+!sql
+!CMakeLists.txt
+!cmake
+!dep
+!config.h.in

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,52 @@
 # This script constitutes the reproducible build environment for EVEmu.
 # Always build EVEmu binaries using docker in a reproducible fashion for issue reporting.
-# Author: jdhirst
-FROM quay.io/fedora/fedora:33-x86_64 as base
-RUN dnf groupinstall -y "Development Tools" && dnf install -y cmake git zlib-devel mariadb-devel boost-devel tinyxml-devel utf8cpp-devel podman buildah mariadb
 
+# This is a multi Stage Build, we start by makeing the base image we will use.
+FROM quay.io/fedora/fedora:33-x86_64 as base
+RUN dnf groupinstall -y "Development Tools" && dnf install -y cmake git zlib-devel mariadb-devel boost-devel tinyxml-devel utf8cpp-devel mariadb shadow-utils
+
+# Now we use the base image to build the project
 FROM base as app-build
+# We Add what we need for the build, if you need to add more; remember you may need to update .dockerignore
 ADD CMakeLists.txt /src/
 ADD config.h.in /src/
 ADD /cmake/ /src/cmake
 ADD /dep/ /src/dep
 ADD /src/ /src/src
 Add /utils/ /src/utils
-RUN ls -al /src
+
+# make some folders we need for the build
 RUN mkdir -p /src/build /app /app/logs /app/server_cache /app/image_cache
+# set our default path for the build
 WORKDIR /src/build
-RUN cmake -DCMAKE_INSTALL_PREFIX=/app -DCMAKE_BUILD_TYPE=Debug ..
+# and run the build
+RUN cmake -DCMAKE_INSTALL_PREFIX=/app -DCMAKE_BUILD_TYPE=Debug .. 
+# we can pull the # of cores on the system and change the build to match the system
 RUN make -j$(nproc)
 RUN make install
 
+
+# Now we switch to makeing the image that will run the code that we have build
 FROM base as app
 LABEL description="EVEmu Server"
+# copy our utils to this image
 COPY --from=app-build /src/utils/ /src/utils
+# add in the files to load the database
 ADD /sql/ /src/sql
+# copy our compiled code to this image
 COPY --from=app-build /app/ /app
+# Create a user group 'EVEmu'
+RUN groupadd EVEmu
+# Create a user 'EVEmu' in group 'EVEmu'
+RUN adduser -b /app -g EVEmu EVEmu
+# Chown all the needed files to the EVEmu user.
+RUN chown -R EVEmu:EVEmu /app && chown -R EVEmu:EVEmu /src
+# Switch to 'appuser'
+USER EVEmu
+
+# Expose the port the server is on.
+EXPOSE 26000
+EXPOSE 26001
+
+# Start the app via the script.
 CMD /src/utils/container-scripts/start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,26 @@
 # This script constitutes the reproducible build environment for EVEmu.
 # Always build EVEmu binaries using docker in a reproducible fashion for issue reporting.
 # Author: jdhirst
+FROM quay.io/fedora/fedora:33-x86_64 as base
+RUN dnf groupinstall -y "Development Tools" && dnf install -y cmake git zlib-devel mariadb-devel boost-devel tinyxml-devel utf8cpp-devel podman buildah mariadb
 
-FROM quay.io/evemu/build-image:latest
-LABEL description="EVEmu Server"
-
-ADD . /src
+FROM base as app-build
+ADD CMakeLists.txt /src/
+ADD config.h.in /src/
+ADD /cmake/ /src/cmake
+ADD /dep/ /src/dep
+ADD /src/ /src/src
+Add /utils/ /src/utils
+RUN ls -al /src
 RUN mkdir -p /src/build /app /app/logs /app/server_cache /app/image_cache
 WORKDIR /src/build
 RUN cmake -DCMAKE_INSTALL_PREFIX=/app -DCMAKE_BUILD_TYPE=Debug ..
-RUN make -j12
+RUN make -j$(nproc)
 RUN make install
 
+FROM base as app
+LABEL description="EVEmu Server"
+COPY --from=app-build /src/utils/ /src/utils
+ADD /sql/ /src/sql
+COPY --from=app-build /app/ /app
 CMD /src/utils/container-scripts/start.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,12 +12,12 @@ services:
       - "26001:26001"
     depends_on:
       - db
+    links:
+      - "db"
   db:
     image: "quay.io/bitnami/mariadb:10.4"
     volumes:
       - db:/bitnami/mariadb
-    ports:
-      - "3306:3306"
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
       - MARIADB_USER=evemu
@@ -28,3 +28,4 @@ volumes:
   config:
   server_cache:
   image_cache:
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
     image: "quay.io/bitnami/mariadb:10.4"
     volumes:
       - db:/bitnami/mariadb
+    # If you want to connect to the Database pick your host port to map it to, (host-port:container-port) below. 
+    #ports:
+    #  - "3306:3306"  
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
       - MARIADB_USER=evemu

--- a/utils/container-scripts/start.sh
+++ b/utils/container-scripts/start.sh
@@ -23,5 +23,3 @@ fi
 echo "Starting eve-server..."
 cd /app/bin/
 ./eve-server
-
-while :; do echo 'EVEmu Halted'; sleep 1; done


### PR DESCRIPTION
This is a small set of changes needed to enable using docker layer caching to speed up local build times, and moving the DB connection to be over the compose link only. 

It has a example of a host port map.

and comments added to the docker file to explain what it is doing.